### PR TITLE
Adicionando integração contínua com travis e codebeat

### DIFF
--- a/.gemrc
+++ b/.gemrc
@@ -1,0 +1,3 @@
+gem: --no-ri --no-rdoc
+install: --no-rdoc --no-ri
+update:  --no-rdoc --no-ri

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ bower.json
 # OSX
 
 .DS_Store
+
+coverage/

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,6 @@ install:
 
 script:
   SUAP_PASSWORD=$SUAP_PASSWORD SUAP_USER=$SUAP_USER RAILS_ENV=test rails test
+
+after_success:
+  - CODECLIMATE_API_HOST=https://codebeat.co/webhooks/code_coverage CODECLIMATE_REPO_TOKEN=$CODECLIMATE_REPO_TOKEN bundle exec codeclimate-test-reporter

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: ruby
+cache: bundler
+dist: trusty
+rvm:
+  - 2.4.1
+
+before_script:
+  - ruby -v
+  - sudo apt-get update -q && sudo apt-get install nodejs -yqq
+  - gem install bundler  --no-ri --no-rdoc
+  - bundle install -j $(nproc) --path vendor
+  - bundle exec rails db:create RAILS_ENV=test
+  - bundle exec rails db:migrate RAILS_ENV=test
+
+install:
+  bundle install
+
+script:
+  SUAP_PASSWORD=$SUAP_PASSWORD SUAP_USER=$SUAP_USER RAILS_ENV=test rails test

--- a/Gemfile
+++ b/Gemfile
@@ -39,5 +39,9 @@ group :development do
   gem 'spring-watcher-listen', '~> 2.0.0'
 end
 
+group :test do
+  gem "simplecov"
+  gem "codeclimate-test-reporter", "~> 1.0.0"
+end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,6 +53,8 @@ GEM
       xpath (~> 2.0)
     childprocess (0.7.0)
       ffi (~> 1.0, >= 1.0.11)
+    codeclimate-test-reporter (1.0.8)
+      simplecov (<= 0.13)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -61,6 +63,7 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.0.5)
+    docile (1.1.5)
     erubi (1.6.0)
     execjs (2.7.0)
     ffi (1.9.18)
@@ -70,6 +73,7 @@ GEM
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
+    json (2.1.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -134,6 +138,11 @@ GEM
       childprocess (~> 0.5)
       rubyzip (~> 1.0)
       websocket (~> 1.0)
+    simplecov (0.13.0)
+      docile (~> 1.1.0)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.1)
     spring (2.0.2)
       activesupport (>= 4.2)
     spring-watcher-listen (2.0.1)
@@ -174,6 +183,7 @@ PLATFORMS
 DEPENDENCIES
   byebug
   capybara (~> 2.13)
+  codeclimate-test-reporter (~> 1.0.0)
   coffee-rails (~> 4.2)
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
@@ -182,6 +192,7 @@ DEPENDENCIES
   rails (~> 5.1.1)
   sass-rails (~> 5.0)
   selenium-webdriver
+  simplecov
   spring
   spring-watcher-listen (~> 2.0.0)
   turbolinks (~> 5)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Horários IFPB
 
+[![Build Status](https://travis-ci.org/joffilyfe/hifpb.svg?branch=master)](https://travis-ci.org/joffilyfe/hifpb)
+[![codebeat badge](https://codebeat.co/badges/d72fdcec-2ed2-41d9-95b0-74d61e06e86b)](https://codebeat.co/projects/github-com-joffilyfe-hifpb-master)
+
 O sistema de controle de horários do Intituto Federal da Paraíba é uma plataforma voltada principalmente o gerenciamento dos horários pelos administradores e coordenadores da instituição, porém para o público geral também há funções como ver os horários de disciplinas, professores e salas de aula.
 
 # Pré requisitos

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,9 @@
+if ENV['RAILS_ENV'] == 'test'
+  require 'simplecov'
+  SimpleCov.start 'rails'
+  puts "required simplecov"
+end
+
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 


### PR DESCRIPTION
Este pull request adiciona a integração com duas ferramentas importantes para o gerenciamento e acompanhamento da qualidade de software.

O travis é responsável por rodar testes e informar se um pull request quebrou alguma parte já existente do projeto. O codebeat por outro lado nos informa sobre a qualidade de escrita de código e quantos % do projeto tem cobertura por testes.
